### PR TITLE
Implement detailed GPT prompt builder

### DIFF
--- a/analysis/gpt_prompter.py
+++ b/analysis/gpt_prompter.py
@@ -1,6 +1,6 @@
 import openai
 import json
-from typing import List, Dict
+from typing import Dict, List
 from utils.secrets import get_secret
 
 # ---------- 読み込み：env.toml ----------
@@ -10,10 +10,30 @@ MAX_TOKENS_MONTH = int(get_secret("openai_max_month_tokens"))
 
 
 def build_messages(payload: Dict) -> List[Dict]:
-    # ここにプロンプト構築ロジックを実装
-    # 例:
+    """payload を英語説明文に整形し、OpenAI 用メッセージを返す"""
+
+    # payload 内の情報を英語で説明文化する
+    lines = [
+        f"UTC timestamp: {payload.get('ts')}",
+        f"Macro regime: {payload.get('reg_macro')}",
+        f"Micro regime: {payload.get('reg_micro')}",
+        f"Technical factors: {json.dumps(payload.get('factors', {}))}",
+        f"Short-term news: {json.dumps(payload.get('news_short', []))}",
+        f"Long-term news: {json.dumps(payload.get('news_long', []))}",
+        f"Performance metrics: {json.dumps(payload.get('perf', {}))}",
+    ]
+
+    user_content = "Here is the latest market data:\n" + "\n".join(lines)
+
+    # GPT への指示は英語で、JSON 形式の回答のみを求める
+    system_content = (
+        "You are an FX trading assistant. Based on the provided market "
+        "information, reply only with a JSON object containing the keys "
+        "'focus_tag', 'weight_macro', and 'ranked_strategies'."
+    )
+
     messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": json.dumps(payload)},
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
     ]
     return messages


### PR DESCRIPTION
## Summary
- build informative payload description in `gpt_prompter`
- request JSON-only answer for FX strategy decision

## Testing
- `black analysis/gpt_prompter.py`
- `ruff check analysis/gpt_prompter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ea03127883338d6d7d065d26ed16