### PR TITLE
Add sample strategy pool config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,32 @@ brew install ta-lib   # macOS
 # ./configure --prefix=/usr && make && sudo make install
 
 # 2. config
-cp config/env.toml config/env.local.toml   # 編集してキーを投入
+cp config/env.toml  config/env.local.toml   # 編集してキーを投入
+cp config/pool.yaml config/pool.local.yaml # 有効戦略を調整
 
 # 3. run (practice account, small lot)
 python main.py
+
+# pool.yaml example
+```yaml
+strategies:
+  - name: TrendMA
+    sl: 30
+    tp: 60
+    enabled: true
+  - name: Donchian55
+    sl: 55
+    tp: 110
+    enabled: true
+  - name: BB_RSI
+    sl: 10
+    tp: 15
+    enabled: true
+  - name: NewsSpikeReversal
+    sl: 10
+    tp: 20
+    enabled: true
+```
 
 Trade Loop Overview
 	1.	Tick → Candle(M1) 生成 → factor_cache 更新

--- a/config/pool.yaml
+++ b/config/pool.yaml
@@ -1,0 +1,17 @@
+strategies:
+  - name: TrendMA
+    sl: 30
+    tp: 60
+    enabled: true
+  - name: Donchian55
+    sl: 55
+    tp: 110
+    enabled: true
+  - name: BB_RSI
+    sl: 10
+    tp: 15
+    enabled: true
+  - name: NewsSpikeReversal
+    sl: 10
+    tp: 20
+    enabled: true


### PR DESCRIPTION
## Summary
- 新しい設定ファイル `config/pool.yaml` を追加
- README に pool.yaml のコピー手順とサンプルを記載

## Testing
- `black --check .` *(fails: would reformat 17 files)*
- `ruff check .` *(fails: found 37 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ea062dc88333920d802ea9f95170