### PR TITLE
Fix pandas_ta import for IndicatorEngine

### DIFF
--- a/indicators/calc_core.py
+++ b/indicators/calc_core.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import Dict
 
 import pandas as pd
+import pandas_ta  # noqa: F401 -- pandasの .ta アクセサを有効化
 
 
 class IndicatorEngine:


### PR DESCRIPTION
## Summary
- enable pandas_ta accessor by importing pandas_ta

## Testing
- `ruff check .`
- `black --check . --line-length 88`
- `python -m compileall -q -f .`

------
https://chatgpt.com/codex/tasks/task_e_6874c813bba083339187c47553b92c41