### PR TITLE
Add ENV_PATH arg to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 FROM python:3.11-slim
+
+ARG ENV_PATH=config/env.example.toml
+
 WORKDIR /app
+
 COPY requirements.txt .
 RUN apt-get update && apt-get install -y build-essential curl
 RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . .
+COPY ${ENV_PATH} ./config/env.toml
+
 CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- use build arg `ENV_PATH` to copy config env file into image

## Testing
- `ruff check .`
- `black --check .`
- `mypy .` *(fails: source file found twice)*


------
https://chatgpt.com/codex/tasks/task_e_68762ceb8d38833382ff3aa3ec5b9a25