### PR TITLE
Add historical candle initialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,11 @@ import datetime
 import logging
 import traceback
 
-from market_data.candle_fetcher import Candle, start_candle_stream
+from market_data.candle_fetcher import (
+    Candle,
+    start_candle_stream,
+    initialize_history,
+)
 from indicators.factor_cache import all_factors, on_candle
 from analysis.regime_classifier import classify
 from analysis.focus_decider import decide_focus
@@ -187,6 +191,7 @@ async def logic_loop():
 
 async def main():
     handlers = [("M1", m1_candle_handler), ("H4", h4_candle_handler)]
+    await initialize_history("USD_JPY")
     await asyncio.gather(start_candle_stream("USD_JPY", handlers), logic_loop())
 
 


### PR DESCRIPTION
## Summary
- add async fetch_historical_candles in `market_data.candle_fetcher`
- add initialize_history to preload candle data into factor cache
- call initialize_history in `main.py` before starting main loops

## Testing
- `black main.py market_data/candle_fetcher.py`
- `ruff check main.py market_data/candle_fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_6876343605ac8333b017322d5848900d